### PR TITLE
Removing unused ENVs from app.json

### DIFF
--- a/App-Template/app.json
+++ b/App-Template/app.json
@@ -26,16 +26,9 @@
       "required": true,
       "value": "enabled"
     },
-    "RAILS_MASTER_KEY": {
-      "required": false
-    },
     "RAILS_MAX_THREADS": {
       "required": true,
       "value": "18"
-    },
-    "RAILS_MIN_THREADS": {
-      "required": true,
-      "value": "5"
     },
     "RAILS_SERVE_STATIC_FILES": {
       "required": true,


### PR DESCRIPTION
We don't require those ENVs by default, so don't push them upon anyone.