### PR TITLE
Caching Gems & node_modules between tests - it's so much faster

### DIFF
--- a/App-Template/.github/workflows/tests.yml
+++ b/App-Template/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
 
 jobs:
   test:
@@ -17,6 +15,28 @@ jobs:
           docker pull ruby:2.7.1-alpine
           docker-compose -f docker-compose.ci.yml pull
       - uses: satackey/action-docker-layer-caching@v0.0.8
+        with:
+          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+      - name: Cache Assets
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+            public/assets
+            public/packs-test
+          key: ${{ runner.os }}-assets-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-assets-
+      - name: Cache gems
+        uses: actions/cache@v2
+        with:
+          path: |
+            vendor/bundle
+          key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bundle-
       - name: Build Latest
         run: |
           docker-compose -f docker-compose.ci.yml build test

--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
     # Fixes watch file issues with things like HMR
     libnotify-dev
 
-FROM builder as development
+FROM builder AS development
 
 # Add the current apps files into docker image
 RUN mkdir -p /usr/src/app
@@ -41,20 +41,7 @@ COPY Gemfile.lock /usr/src/app
 COPY package.json /usr/src/app
 COPY yarn.lock /usr/src/app
 
-FROM shared-production AS ci
-
-# Install Ruby Gems
-RUN bundle check || bundle install --jobs=$(nproc)
-
-# Install Yarn Libraries
-RUN yarn install --check-files
-
-# Copy the rest of the app
-COPY . /usr/src/app
-
-CMD ["bundle", "exec", "rspec"]
-
-FROM shared-production AS production
+FROM development AS production
 
 # Install Ruby Gems
 RUN bundle config set deployment 'true'

--- a/App-Template/docker-compose.ci.yml
+++ b/App-Template/docker-compose.ci.yml
@@ -9,14 +9,18 @@ x-ci-app: &ci-app
   build:
     context: .
     dockerfile: Dockerfile
-    target: ci
+    target: development
   environment:
     DATABASE_URL: postgres://postgres:postgres@postgres:5432/
     RAILS_ENV: test
     RACK_ENV: test
+    BUNDLE_PATH: /usr/src/app/vendor/bundle
   volumes:
-    - packs:/usr/src/app/public/packs:delegated
-    - public_assets:/usr/src/app/public/assets:delegated
+    - .:/usr/src/app:cached
+    - ./node_modules:/usr/src/app/node_modules:cached
+    - ./public/assets:/usr/src/app/public/assets:cached
+    - ./public/packs-test:/usr/src/app/public/packs-test:cached
+    - ./vendor/bundle:/usr/src/app/vendor/bundle:cached
   depends_on:
     postgres:
       condition: service_healthy
@@ -40,8 +44,4 @@ services:
 
   test:
     <<: *ci-app
-    command: bash -c "bundle exec rails db:setup && bundle exec rake assets:precompile && bundle exec rspec"
-
-volumes:
-  packs:
-  public_assets:
+    command: bash -c "bin/setup && bundle exec rake assets:precompile && bundle exec rspec"


### PR DESCRIPTION
I've been experimenting a little with using `actions/checkout@v1` to cache layers of the docker images, it appears to work quite nicely.