### PR TITLE
Simplifying rubocop setup a bit more

### DIFF
--- a/App-Template/.rubocop.yml
+++ b/App-Template/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
-  NewCops: enable
+  NewCops: disable
   Exclude:
     - 'db/schema.rb'
     - 'node_modules/**/*'
@@ -13,11 +13,5 @@ AllCops:
     - 'bin/*'
     - 'tmp/**/*'
 
-Bundler/OrderedGems:
-  Enabled: true
-
 Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/HashSyntax:
   Enabled: false


### PR DESCRIPTION
I really want to cutdown the amount of rubocop config to be close to zero (Like standardrb, but still rubocop).

This seemed like a good step in the right direction. 