### PR TITLE
Allowing .envs to store DATABASE_URL/REDIS_URL

### DIFF
--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -71,6 +71,10 @@ jobs:
         bundle remove jbuilder
         bundle remove web-console
 
+        echo "Updating .gitignore to ignore .env files"
+        cat .gitignore.append >> .gitignore
+        rm .gitignore.append
+
         echo "Adding gems I often add next"
         cat Gemfile.append >> Gemfile
         rm Gemfile.append

--- a/App-Template/.env.example
+++ b/App-Template/.env.example
@@ -1,0 +1,6 @@
+# If you want, you can run:
+# $ docker compose up redis postgres
+# $ bundle exec rails s
+# I know for some people it's a little more performant :)
+REDIS_URL= redis://@127.0.0.1:6379/1
+DATABASE_URL= postgres://postgres:postgres@127.0.0.1:5432/

--- a/App-Template/.gitignore.append
+++ b/App-Template/.gitignore.append
@@ -1,0 +1,3 @@
+
+# Ignore .envs - They store environmental variables
+.env


### PR DESCRIPTION
I saw in https://github.com/lewispb/mame-challenge/blob/master/.env.example ( Thank you @lewispb !) that they use Docker for the database/redis, but run Rails on the local machine.

I really liked that approach, so copying it :D