### PR TITLE
Adding rubocop-performance to default workflows

### DIFF
--- a/App-Template/.github/workflows/rubocop.yml
+++ b/App-Template/.github/workflows/rubocop.yml
@@ -27,5 +27,6 @@ jobs:
         gem install rubocop
         gem install rubocop-rails
         gem install rubocop-rspec
+        gem install rubocop-performance
     - name: Run RuboCop
       run: rubocop --parallel


### PR DESCRIPTION
I totally forgot to add `rubocop-performance`, which meant the rubocop default workflow was failing.