### PR TITLE
Retagging satackey/action-docker-layer-caching to v0

### DIFF
--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/App
         docker-compose pull
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0
     - name: Test we can build docker
       run: |
         cd $GITHUB_WORKSPACE/App

--- a/App-Template/.github/workflows/tests.yml
+++ b/App-Template/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           docker pull ruby:2.7.2-alpine
           docker-compose -f docker-compose.ci.yml pull
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0
         with:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: |


### PR DESCRIPTION
It seem like that github action is being updated pretty often, so making we don't get overwhelemed with notifications.