### PR TITLE
Telling ruby/setup-ruby to not install a different version of bundler

### DIFF
--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -3,7 +3,7 @@ name: Update Template Repo
 on:
   push:
     branches:
-      - master
+      #- master
   schedule:
     - cron:  '0 5 1 * *'
 
@@ -27,7 +27,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.2
-        bundler: 2.1.4
+        bundler: none
     - uses: actions/cache@v2
       with:
         path: ${{ github.workspace }}/vendor/bundle

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -3,7 +3,7 @@ name: Update Template Repo
 on:
   push:
     branches:
-      #- master
+      - master
   schedule:
     - cron:  '0 5 1 * *'
 

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -27,6 +27,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.2
+        bundler: 2.1.4
     - uses: actions/cache@v2
       with:
         path: ${{ github.workspace }}/vendor/bundle


### PR DESCRIPTION
It updated the version of bundler it was using instead of just using the one which ships with 2.7.2.

It changed in https://github.com/ruby/setup-ruby/commit/3e7640a17e0235a5631a1e884c9316d337ab8c35 - But I'm going to stick with the default version.