### PR TITLE
Adding Bootsnap precompile to Dockerfile

### DIFF
--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -32,7 +32,7 @@ RUN bundle config --global silence_root_warning 1
 EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0", "-p", "3000"]
 
-FROM development AS shared-production
+FROM development AS production
 
 COPY Gemfile /usr/src/app
 COPY .ruby-version /usr/src/app
@@ -40,8 +40,6 @@ COPY Gemfile.lock /usr/src/app
 
 COPY package.json /usr/src/app
 COPY yarn.lock /usr/src/app
-
-FROM development AS production
 
 # Install Ruby Gems
 RUN bundle config set deployment 'true'
@@ -54,5 +52,8 @@ RUN yarn install --check-files
 # Copy the rest of the app
 COPY . /usr/src/app
 
-# Compile the assets
+# Precompile the assets
 RUN RAILS_SERVE_STATIC_FILES=enabled SECRET_KEY_BASE=secret-key-base RAILS_ENV=production RACK_ENV=production NODE_ENV=production bundle exec rake assets:precompile
+
+# Precompile Bootsnap
+run RAILS_SERVE_STATIC_FILES=enabled SECRET_KEY_BASE=secret-key-base RAILS_ENV=production RACK_ENV=production NODE_ENV=production bundle exec bootsnap precompile --gemfile app/ lib/


### PR DESCRIPTION
I read a bit more into [bootsnap + docker](https://github.com/Shopify/bootsnap#precompilation), it looks like you can speed up the app boot time when using the docker image.

While I don't use Docker in production, I do digg sharing this feature.