### PR TITLE
Stop outputting postgres logs to ./log

### DIFF
--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -43,7 +43,6 @@ services:
     image: postgres:12.3-alpine
     mem_limit: 64m
     volumes:
-      - ./log:/root/log:cached
       - postgresql:/var/lib/postgresql/data:delegated
     ports:
       - "127.0.0.1:5432:5432"

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     image: postgres:12.3-alpine
     mem_limit: 64m
     volumes:
+      - ./log/postgres:/root/log:cached
       - postgresql:/var/lib/postgresql/data:delegated
     ports:
       - "127.0.0.1:5432:5432"

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -43,7 +43,6 @@ services:
     image: postgres:12.3-alpine
     mem_limit: 64m
     volumes:
-      - ./log/postgres:/root/log:cached
       - postgresql:/var/lib/postgresql/data:delegated
     ports:
       - "127.0.0.1:5432:5432"


### PR DESCRIPTION
Fixes: https://github.com/Ruby-Starter-Kits/Docker-Rails-Generator/issues/49

The folder being mounted was not writeable, so it was causing weirdness. So removing that line as I don't actually use it.