### PR TITLE
Changing missed reference to Rubocop > Standard

### DIFF
--- a/App-Template/.github/workflows/standard.yml
+++ b/App-Template/.github/workflows/standard.yml
@@ -23,5 +23,5 @@ jobs:
       run: |
         bundle config path vendor/bundle
         gem install standardrb
-    - name: Run RuboCop
+    - name: Run Standard
       run: standardrb


### PR DESCRIPTION
I missed a reference to rubocop which needed updating.