### PR TITLE
Setting the default branch when pushing

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,9 @@
 name: Changelog
 
 on:
+  workflow_dispatch:
+  release:
+    types: [created]
   push:
     branches:
       - master
@@ -13,20 +16,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u Ruby-Starter-Kits -p Docker-Rails-Generator --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"
@@ -36,4 +39,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: master
+        branch: ${{ github.ref }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,3 +36,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -88,3 +88,4 @@ jobs:
         repository: 'Ruby-Starter-Kits/Docker-Rails-Template'
         branch: master
         directory: App
+        branch: ${{ github.ref }}

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -86,4 +86,5 @@ jobs:
       with:
         github_token: ${{ secrets.LOCAL_GIT_TOKEN }}
         repository: 'Ruby-Starter-Kits/Docker-Rails-Template'
+        branch: master
         directory: App


### PR DESCRIPTION
My build setup is currently broken due to https://github.com/ad-m/github-push-action/pull/69

I'm going to sleep on it, but this could be a good time to migrate my repos over to the `main` default branch.