### PR TITLE
Re-adding the volumes to the main docker container

### DIFF
--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -42,6 +42,8 @@ RUN apk --no-cache add \
 FROM builder AS development
 
 # Set common ENVs
+ENV BOOTSNAP_CACHE_DIR /usr/src/bootsnap
+ENV YARN_CACHE_FOLDER /usr/src/yarn
 ENV EDITOR vim
 ENV LANG en_US.UTF-8
 ENV BUNDLE_PATH /usr/local/bundle
@@ -61,8 +63,15 @@ RUN bundle config set jobs $(nproc)
 
 # Create app directory in the conventional /usr/src/app
 RUN mkdir -p /usr/src/app \
+      && mkdir -p /usr/src/app/node_modules \
+      && mkdir -p /usr/src/app/public/packs \
+      && mkdir -p /usr/src/app/tmp/cache \
+      && mkdir -p $YARN_CACHE_FOLDER \
+      && mkdir -p $BOOTSNAP_CACHE_DIR \
       && chown -R appuser:appgroup /usr/src/app \
-      && chown -R appuser:appgroup $BUNDLE_PATH
+      && chown -R appuser:appgroup $BUNDLE_PATH \
+      && chown -R appuser:appgroup $BOOTSNAP_CACHE_DIR \
+      && chown -R appuser:appgroup $YARN_CACHE_FOLDER
 WORKDIR /usr/src/app
 
 ENV PATH /usr/src/app/bin:$PATH

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -28,6 +28,12 @@ x-app: &app
   volumes:
     - .:/usr/src/app:cached
     - bundler:/usr/local/bundle:delegated
+    - bootsnap_cache:/usr/src/bootsnap:delegated
+    - rails_cache:/usr/src/app/tmp/cache:delegated
+    - packs:/usr/src/app/public/packs:delegated
+    - node_modules:/usr/src/app/node_modules:delegated
+    - yarn_cache:/usr/src/yarn:delegated
+    - letter_opener:/usr/src/app/tmp/letter_opener:delegated
   depends_on:
     postgres:
       condition: service_healthy
@@ -89,3 +95,9 @@ volumes:
   postgresql:
   redis:
   bundler:
+  bootsnap_cache:
+  rails_cache:
+  packs:
+  node_modules:
+  yarn_cache:
+  letter_opener:


### PR DESCRIPTION
I pulled down the version which didn't have the volumes, and it was super slow. Plus when I ran `yarn` outside of docker, it caused all sorts of conflicts.

So adding them back in for sanity.