### PR TITLE
Clearing logs on startup

### DIFF
--- a/App-Template/config/initializers/opinionated_defaults/logger.rb
+++ b/App-Template/config/initializers/opinionated_defaults/logger.rb
@@ -1,0 +1,5 @@
+Rails.application.config do
+  if Rails.env.development?
+    config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 50.megabytes)
+  end
+end

--- a/App-Template/config/initializers/opinionated_defaults/logger.rb
+++ b/App-Template/config/initializers/opinionated_defaults/logger.rb
@@ -1,5 +1,3 @@
-Rails.application.config do
-  if Rails.env.development?
-    config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 50.megabytes)
-  end
+if Rails.env.development?
+  Rails.logger = ActiveSupport::Logger.new(Rails.application.config.paths['log'].first, 1, 50.megabytes)
 end

--- a/App-Template/config/initializers/opinionated_defaults/logger.rb
+++ b/App-Template/config/initializers/opinionated_defaults/logger.rb
@@ -1,3 +1,5 @@
+# By default Rails will keep writing to logs/development.log, this can lead to really large files.
+# Let's configure this to be at most 50mb.
 if Rails.env.development?
   Rails.logger = ActiveSupport::Logger.new(Rails.application.config.paths['log'].first, 1, 50.megabytes)
 end


### PR DESCRIPTION
https://mikerogers.io/2018/11/11/stop-rails-log-files-growing-to-much - It's handy to clear the development logs on startup, so adding something to clear it.