### PR TITLE
Using ENV["URL"] for setting URL of host

### DIFF
--- a/App-Template/.env.example
+++ b/App-Template/.env.example
@@ -4,3 +4,7 @@
 # I know for some people it's a little more performant :)
 REDIS_URL=redis://@127.0.0.1:6379/1
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/
+
+# Set a default host value - Useful for mailers & _url routes.
+URL=127.0.0.1:3000
+URL_PROTOCOL=http

--- a/App-Template/config/initializers/opinionated_defaults/default_url_options.rb
+++ b/App-Template/config/initializers/opinionated_defaults/default_url_options.rb
@@ -1,8 +1,8 @@
 # Sets the default URL options to the URL env.
 if ENV["URL"].present?
   Rails.application.default_url_options = {
-    host: ENV["URL"],
-    protocol: "https"
+    host: ENV.fetch("URL", "127.0.0.1"),
+    protocol: ENV.fetch("URL_PROTOCOL", "https")
   }
 elsif ENV["HEROKU_APP_NAME"].present?
   Rails.application.default_url_options = {

--- a/App-Template/config/initializers/opinionated_defaults/logger.rb
+++ b/App-Template/config/initializers/opinionated_defaults/logger.rb
@@ -1,5 +1,5 @@
 # By default Rails will keep writing to logs/development.log, this can lead to really large files.
 # Let's configure this to be at most 50mb.
 if Rails.env.development?
-  Rails.logger = ActiveSupport::Logger.new(Rails.application.config.paths['log'].first, 1, 50.megabytes)
+  Rails.logger = ActiveSupport::Logger.new(Rails.application.config.paths["log"].first, 1, 50.megabytes)
 end


### PR DESCRIPTION
I like to use `ENV["URL"]` for the host, it's a nice way to configure the sites current URL.

However, I noticed it didn't work quite nicely for local dev recently. So setting better defaults. 