### PR TITLE
Removing RAILS_ENV from Procfile

### DIFF
--- a/App-Template/Procfile
+++ b/App-Template/Procfile
@@ -3,7 +3,7 @@
 release: bash bin/release-tasks.sh
 
 ## Web Instance, this'll serve TCP requests
-web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+web: bin/rails server -p ${PORT:-5000}
 
 ## Sidekiq is the de-facto standard choice for running Background tasks
 # worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
I started messing around with running the project via Overmind & Foreman,  and it wouldn't start unless I set the RAILS_ENV variable.

It's not really required, so out the box I'm ditching it.