### PR TITLE
Readding rubocop.yml for build-stage

### DIFF
--- a/App-Template/rubocop.yml
+++ b/App-Template/rubocop.yml
@@ -1,6 +1,8 @@
+# This reformats the Rails to follow the Rubocop cop basic standard, it's there because StandardRB
+# still isn't perfect.
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: disable
   Exclude:
     - 'db/schema.rb'

--- a/App-Template/rubocop.yml
+++ b/App-Template/rubocop.yml
@@ -1,0 +1,14 @@
+
+AllCops:
+  TargetRubyVersion: 2.7
+  NewCops: disable
+  Exclude:
+    - 'db/schema.rb'
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
+    - 'bin/*'
+    - 'tmp/**/*'
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
I just noticed we had `frozen_string_literal` everywhere (BOO!!!!). Turns out that's what the `rubocop.yml` file was there for.