### PR TITLE
Not sharing redis/postgres ports with host machine by default

### DIFF
--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -46,8 +46,9 @@ services:
     mem_limit: 64m
     volumes:
       - postgresql:/var/lib/postgresql/data:delegated
-    ports:
-      - "127.0.0.1:5432:5432"
+    # Uncomment to access this containers postgres instance via port 5432
+    #ports:
+      #- "127.0.0.1:5432:5432"
     environment:
       PSQL_HISTFILE: /root/log/.psql_history
       POSTGRES_USER: postgres
@@ -66,8 +67,9 @@ services:
     mem_limit: 64m
     volumes:
       - redis:/data:delegated
-    ports:
-      - "127.0.0.1:6379:6379"
+    # Uncomment to access this containers redis instance via port 6379
+    #ports:
+      #- "127.0.0.1:6379:6379"
     restart: on-failure
     logging:
       driver: none


### PR DESCRIPTION
I worked with a few users setting this up & their local postgres/redis instance was interfering with the one opened up by docker.

So by default, I'm going to disable these with a comment :) // @andrewculver 