### PR TITLE
Upgrading to Postgres 13.2 & Redis 6.0.12

### DIFF
--- a/App-Template/.github/workflows/tests.yml
+++ b/App-Template/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Pull docker images
         run: |
           docker pull ruby:3.0.0-alpine
+          docker pull postgres:13.2-alpine
           docker-compose -f docker-compose.ci.yml pull
       - uses: satackey/action-docker-layer-caching@v0
         with:

--- a/App-Template/docker-compose.ci.yml
+++ b/App-Template/docker-compose.ci.yml
@@ -31,7 +31,7 @@ x-ci-app: &ci-app
 
 services:
   postgres:
-    image: postgres:12.3-alpine
+    image: postgres:13.2-alpine
     mem_limit: 64m
     environment:
       POSTGRES_USER: postgres

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -42,7 +42,7 @@ x-app: &app
 
 services:
   postgres:
-    image: postgres:12.3-alpine
+    image: postgres:13.2-alpine
     mem_limit: 64m
     volumes:
       - postgresql:/var/lib/postgresql/data:delegated
@@ -63,7 +63,7 @@ services:
       driver: none
 
   redis:
-    image: redis:4.0.14-alpine
+    image: redis:6.0.12-alpine
     mem_limit: 64m
     volumes:
       - redis:/data:delegated


### PR DESCRIPTION
This upgrades the default postgres & redis version to the latest versions offered by Heroku.

I didn't realised Redis was two versions behind until Heroku emailed me to say my apps I created 6 months ago had an addon approach EOL https://devcenter.heroku.com/changelog-items/2078 