### PR TITLE
Locking github_changelog_generator to v1.15.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
-        gem install github_changelog_generator
+        gem install github_changelog_generator -v "1.15.2"
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |


### PR DESCRIPTION
https://github.com/Ruby-Starter-Kits/Docker-Rails-Generator/runs/2231255906?check_suite_focus=true - Right now `github_changelog_generator` is throwing an exception for me.

it looks to be reported ( https://github.com/github-changelog-generator/github-changelog-generator/issues/952 ), for now I'm going to stick to an older version.