### PR TITLE
feat: Increasing timeout and retry interval

### DIFF
--- a/App-Template/bin/docker/entrypoints/wait-for-postgres.sh
+++ b/App-Template/bin/docker/entrypoints/wait-for-postgres.sh
@@ -4,7 +4,7 @@ set -e
 # Wait for Postgres to start before doing anything
 echo ""
 echo "== ⏱  Waiting for Postgres before running: $@ =="
-dockerize -wait tcp://postgres:5432
+dockerize -wait tcp://postgres:5432 -timeout 60s -wait-retry-interval 5s
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 echo ""

--- a/App-Template/bin/docker/entrypoints/wait-for-web.sh
+++ b/App-Template/bin/docker/entrypoints/wait-for-web.sh
@@ -4,7 +4,7 @@ set -e
 # Wait for Web to start before doing anything
 echo ""
 echo "== ⏱  Waiting for Postgres & Web to start before running: $@ =="
-dockerize -wait tcp://postgres:5432 -wait tcp://web:3000
+dockerize -wait tcp://postgres:5432 -wait tcp://web:3000 -timeout 60s -wait-retry-interval 5s
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 echo ""


### PR DESCRIPTION
Sometimes webpacker can take a long moment to successfully build, sometimes this can take a long time. So just in case wait a bit longer by default for everything to turn on.