### PR TITLE
fix: Explicitly setting ActiveJob queue adapter

### DIFF
--- a/App-Template/config/initializers/opinionated_defaults/sidekiq.rb
+++ b/App-Template/config/initializers/opinionated_defaults/sidekiq.rb
@@ -31,6 +31,8 @@ if defined?(Sidekiq) && ENV["REDIS_URL"].present?
     network_timeout: 5
   }
   Rails.application.config.active_job.queue_adapter = :sidekiq
+  ActiveJob::Base.queue_adapter = :sidekiq
 else
   Rails.application.config.active_job.queue_adapter = :inline
+  ActiveJob::Base.queue_adapter = :inline
 end

--- a/App-Template/spec/support/active_job.rb
+++ b/App-Template/spec/support/active_job.rb
@@ -1,0 +1,1 @@
+ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
It appears settings `Rails.application.config.active_job.queue_adapter` doesn't change the `ActiveJob::Base.queue_adapter` if it's already been set by something else (This could lead to jobs being run async instead of in sidekiq).

So to combat this, I'm explicitly setting this value.