### PR TITLE
feat: Move common docker commands into bin files

### DIFF
--- a/App-Template/README.md
+++ b/App-Template/README.md
@@ -13,9 +13,8 @@ Welcome to your [Ruby On Rails](https://rubyonrails.org/) app.
 Clone down the repo, install [Docker](https://hub.docker.com/editions/community/docker-ce-desktop-mac/) & run:
 
 ```bash
-$ docker-compose build
-$ docker-compose run --rm web bin/setup
-$ docker-compose up
+$ ./bin/docker/setup
+$ ./bin/docker/start
 ```
 
 This will build the docker image, then setup the `bin/setup` file which will run `bundle`, `yarn` & create the database.
@@ -27,9 +26,9 @@ Then navigate your browser to https://127.0.0.1:3000/ to see your site.
 To run a one off command, run it within the web service, e.g:
 
 ```bash
-$ docker-compose run --rm web bin/rails db:migrate
-$ docker-compose run --rm web bin/bundle
-$ docker-compose run --rm web bin/yarn
+$ ./bin/docker/bundle exec rails db:migrate
+$ ./bin/docker/bundle
+$ ./bin/docker/yarn
 ```
 
 ### Restoring a database

--- a/App-Template/bin/docker/bash
+++ b/App-Template/bin/docker/bash
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -e
 

--- a/App-Template/bin/docker/bash
+++ b/App-Template/bin/docker/bash
@@ -1,0 +1,5 @@
+
+#!/bin/bash
+set -e
+
+docker-compose run --rm web bash

--- a/App-Template/bin/docker/bundle
+++ b/App-Template/bin/docker/bundle
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec docker-compose --rm web bundle "$@"

--- a/App-Template/bin/docker/setup
+++ b/App-Template/bin/docker/setup
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require "fileutils"
+
+# path to your application root.
+APP_ROOT = File.expand_path("../../", __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  # This turns sets up up the docker image
+  puts "\n== Copying sample files =="
+  unless File.exist?(".env")
+    FileUtils.cp ".env.template", ".env"
+  end
+
+  puts "== Pulling Images =="
+  system! "docker-compose pull"
+
+  puts "== Building Container =="
+  system! "docker-compose build"
+
+  puts "== Installing Libraries =="
+  system! "docker-compose run --rm web ./bin/setup"
+
+  puts "== 🎉 Success, now you can run ./bin/bin/docker/start"
+end

--- a/App-Template/bin/docker/setup
+++ b/App-Template/bin/docker/setup
@@ -24,5 +24,5 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing Libraries =="
   system! "docker-compose run --rm web ./bin/setup"
 
-  puts "== 🎉 Success, now you can run ./bin/bin/docker/start"
+  puts "== 🎉 Success, now you can run ./bin/docker/start"
 end

--- a/App-Template/bin/docker/start
+++ b/App-Template/bin/docker/start
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "== Turning on Docker =="
+docker-compose up

--- a/App-Template/bin/docker/yarn
+++ b/App-Template/bin/docker/yarn
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec docker-compose --rm web yarn "$@"


### PR DESCRIPTION
I read @davetron5000 book "Sustainable Web Development" & one of the things which has made a big impact on my day-to-day work is having common docker commands extracted into `./bin/docker` files.

Since adopting it, I've really enjoying being able to casually run:

```
$ git checkout -b <some-branch-name> && ./bin/docker/setup && ./bin/docker/start
```

Then get a fresh environment with new seeds & whatnot :D So I want to make sure I encourage it here.
