### PR TITLE
fix: Mailtrap was unable to load the JSON as open() wasn't loaded

### DIFF
--- a/App-Template/config/initializers/opinionated_defaults/action_mailer.rb
+++ b/App-Template/config/initializers/opinionated_defaults/action_mailer.rb
@@ -2,7 +2,10 @@ Rails.application.configure do
   # Default to Mailtrap if we have it, then fallback to sendgrid then SENDGRID_USERNAME.
   # If nothing is present. don't send emails (Which each environment can override if needed).
   if ENV["MAILTRAP_API_TOKEN"].present?
-    first_inbox = JSON.parse(open("https://mailtrap.io/api/v1/inboxes.json?api_token=#{ENV["MAILTRAP_API_TOKEN"]}").read)[0]
+    require "net/http"
+    require "uri"
+    require "json"
+    first_inbox = JSON.parse(Net::HTTP.get(URI.parse("https://mailtrap.io/api/v1/inboxes.json?api_token=#{ENV["MAILTRAP_API_TOKEN"]}")))[0]
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
       user_name: first_inbox["username"],


### PR DESCRIPTION
`Errno::ENOENT: No such file or directory @ rb_sysopen `

I ran into this problem building a preview app, so solving this.